### PR TITLE
Changing connect-assets dependency to 2.1.4 (for Heroku support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "coffee-script": "1.1.x"
     , "express": "2.5.x" 
     , "jade": "0.x.x"
-    , "connect-assets": "2.1.x"
+    , "connect-assets": "2.1.4"
     , "stylus": "*"
     , "nib": "*"
     , "markdown": "*"


### PR DESCRIPTION
Changing connect-assets dependency to 2.1.4, because 2.1.5 requires connect-file-cache 0.2.4 which in turn requires node >= 0.6.1. Heroku runs 0.4.7.
