### PR TITLE
Fix Deploy on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   , "private": true
   , "dependencies": {
     "express": "3.x" 
+    , "coffee-script": "1.3.3"
     , "jade": "0.26.0"
     , "connect-assets": "2.2.1"
     , "stylus": "0.27.0"
@@ -11,6 +12,7 @@
     , "markdown": "0.3.1"
     , "which": "*"
   }, "scripts": {
+    "install": "node_modules/coffee-script/bin/cake build",
     "start": "node server.js",
     "test": "mocha --require should --compilers coffee:coffee-script --colors"
   }, "devDependencies": {


### PR DESCRIPTION
Deploy on heroku without compiled files. Use install to convert coffee to js files.
