### PR TITLE
Minor install script bug in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     , "markdown": "0.3.1"
     , "which": "*"
   }, "scripts": {
-    "install": "node_modules/coffee-script/bin/cake build",
+    "install": "node node_modules/coffee-script/bin/cake build",
     "start": "node server.js",
     "test": "mocha --require should --compilers coffee:coffee-script --colors"
   }, "devDependencies": {


### PR DESCRIPTION
Windows needs a `node` in front of `node_modules/coffee-script/bin/cake build`
