### PR TITLE
fix syntax error during `cake test`

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -35,7 +35,7 @@ test = (callback) ->
     '--reporter'
     'spec'
     '--compilers'
-    'coffee:coffee-script'
+    'coffee:coffee-script/register'
     '--colors'
     '--require'
     'should'


### PR DESCRIPTION
Coffeescript 1.7.1 broke the mocha test. Found this solution at:

https://github.com/visionmedia/mocha/commit/2f42a833555f6e7b61c75e50114c15fc9ab00a16

The exact error looks like this:

set app environment: development

/private/tmp/express-coffee/test/app_test.coffee:1
xports, require, module, __filename, __dirname) { request = require 'supertest
                                                                    ^^^^^^^^^^^
SyntaxError: Unexpected string
  at Module._compile (module.js:439:25)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at /usr/local/lib/node_modules/mocha/lib/mocha.js:172:27
  at Array.forEach (native)
  at Mocha.loadFiles
(/usr/local/lib/node_modules/mocha/lib/mocha.js:169:14)
  at Mocha.run (/usr/local/lib/node_modules/mocha/lib/mocha.js:356:31)
  at Object.<anonymous>
(/usr/local/lib/node_modules/mocha/bin/_mocha:359:16)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:902:3
