### PR TITLE
updates npm test script to use v1.7 of coffeescript compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "express-coffee", 
-	"version": "1.8.1",
-	"private": true,
-	"author": "Tom Wilson <tom@jackhq.com> (http://github.com/twilson63)",
-	"repository": {
-	  "type": "git",
-	  "url": "https://github.com/twilson63/express-coffee"
-	},
+  "name": "express-coffee",
+  "version": "1.8.1",
+  "private": true,
+  "author": "Tom Wilson <tom@jackhq.com> (http://github.com/twilson63)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twilson63/express-coffee"
+  },
   "scripts": {
-	    "install": "node node_modules/coffee-script/bin/cake build",
-	    "start": "node server.js",
-	    "test": "mocha --require should --compilers coffee:coffee-script --colors"
-	}, 
-	"dependencies": {
-		"express": "4.x",
-		"coffee-script": "1.7.x",
-		"jade": "1.3.x",
-		"connect-assets": "2.5.x",
-		"stylus": "0.43.x",
-		"nib": "0.9.x",
-		"markdown": "0.4.0",
-		"which": "1.0.5",
-		"mongoose": "3.8.x",
-		"express-session": "1.0.x",
-		"cookie-parser": "1.0.x",
-		"body-parser": "1.0.x",
-		"wrench": "1.5.x"
-	}, 
-	"devDependencies": {
-		"coffee-script": "*",
+    "install": "node node_modules/coffee-script/bin/cake build",
+    "start": "node server.js",
+    "test": "mocha --require should --compilers coffee:coffee-script/register --colors"
+  },
+  "dependencies": {
+    "express": "4.x",
+    "coffee-script": "1.7.x",
+    "jade": "1.3.x",
+    "connect-assets": "2.5.x",
+    "stylus": "0.43.x",
+    "nib": "0.9.x",
+    "markdown": "0.4.0",
+    "which": "1.0.5",
+    "mongoose": "3.8.x",
+    "express-session": "1.0.x",
+    "cookie-parser": "1.0.x",
+    "body-parser": "1.0.x",
+    "wrench": "1.5.x"
+  },
+  "devDependencies": {
+    "coffee-script": "*",
     "mocha": "*",
     "should": "*",
     "supertest": "*",
@@ -38,36 +38,36 @@
     "puts": "*",
     "node-inspector": "*",
     "ejs": "*"
-	}, 
-	"engines": {
-		"node": "~0.10.x",
-		"npm": "1.2.x"
-	},
-	"licenses": [
-	  {
-	    "type": "MIT",
-	    "url": "http://www.opensource.org/licenses/mit-license.php" 
-	  }
-	],
-	"contributors": [
-	  "Jorrit Posthuma <> (https://github.com/JorritPosthuma)",
-	  "Jacob Gable <jacob.gable@gmail.com> (http://jacob4u2.posterous.com)",
-	  "Michael de Silva <michael@mwdesilva.com> (http://www.mwdesilva.com)",
-	  "Jimmy Chao <daizenga@gmail.com> (http://neethack.com)",
-	  "Sergey Klimov <sergey.v.klimov@gmail.com> (https://twitter.com/#!/sergey_v_klimov)",
-	  "Adrien Brault <> (https://github.com/adrienbrault)",
-	  "Sandro Padin <> (https://github.com/spadin)",
-	  "Cody Russell <> (https://github.com/bratsche)",
-	  "Wes Cruver <> (https://github.com/chieffancypants)",
-	  "Arthur Gautier <> (https://github.com/baloo)",
-	  "Jaime Pillora <> (https://github.com/jpillora)",
-	  "Steven Shingler <> (https://github.com/sshingler)",
-	  "Johnny Gannon <> (https://github.com/jgannonjr)",
-	  "Zachery Hostens <> (https://github.com/zacheryph)",
-	  "Fernando <> (https://github.com/fern4lvarez)",
-	  "John Katsnelson <> (https://github.com/jkatsnelson)",
-	  "Craig Ulliott <> (https://github.com/craigulliott)",
-	  "Shaun Kirk Wong <shaun.kirk.wong@gmail.com> (https://github.com/skw)",
-	  "Justin Collum <> (https://github.com/jcollum)"
-	]
+  },
+  "engines": {
+    "node": "~0.10.x",
+    "npm": "1.2.x"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "contributors": [
+    "Jorrit Posthuma <> (https://github.com/JorritPosthuma)",
+    "Jacob Gable <jacob.gable@gmail.com> (http://jacob4u2.posterous.com)",
+    "Michael de Silva <michael@mwdesilva.com> (http://www.mwdesilva.com)",
+    "Jimmy Chao <daizenga@gmail.com> (http://neethack.com)",
+    "Sergey Klimov <sergey.v.klimov@gmail.com> (https://twitter.com/#!/sergey_v_klimov)",
+    "Adrien Brault <> (https://github.com/adrienbrault)",
+    "Sandro Padin <> (https://github.com/spadin)",
+    "Cody Russell <> (https://github.com/bratsche)",
+    "Wes Cruver <> (https://github.com/chieffancypants)",
+    "Arthur Gautier <> (https://github.com/baloo)",
+    "Jaime Pillora <> (https://github.com/jpillora)",
+    "Steven Shingler <> (https://github.com/sshingler)",
+    "Johnny Gannon <> (https://github.com/jgannonjr)",
+    "Zachery Hostens <> (https://github.com/zacheryph)",
+    "Fernando <> (https://github.com/fern4lvarez)",
+    "John Katsnelson <> (https://github.com/jkatsnelson)",
+    "Craig Ulliott <> (https://github.com/craigulliott)",
+    "Shaun Kirk Wong <shaun.kirk.wong@gmail.com> (https://github.com/skw)",
+    "Justin Collum <> (https://github.com/jcollum)"
+  ]
 }


### PR DESCRIPTION
The DevDependencies in package.json don't specify a version for coffee-script so if you npm install today (or update installed modules) coffee-script 1.7 will be installed. This requires using a slightly different compiler value for mocha (see: http://visionmedia.github.io/mocha/#compilers-option) or the tests will not run. 
