### PR TITLE
Added parenthesis to done in app_test and replaced .includes with .co…

### DIFF
--- a/test/app_test.coffee
+++ b/test/app_test.coffee
@@ -9,7 +9,7 @@ describe 'General', ->
         .get("/")
         .send( {} )
         .expect(200, {},
-                done
+                done()
         )
 
   describe "404 Routing", ->
@@ -18,5 +18,5 @@ describe 'General', ->
         .get('/nonexistent/action')
         .send( {} )
         .expect(404, {},
-                done
+                done()
         )

--- a/test/posts_test.coffee
+++ b/test/posts_test.coffee
@@ -30,7 +30,7 @@ describe 'Post', ->
       .post("/posts/create")
       .send(POST_DATA)
       .expect 201, (err, res) ->
-        res.body.should.include(POST_DATA)
+        res.body.should.containEql(POST_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.ok
         post_id = res.body["_id"]
@@ -40,7 +40,7 @@ describe 'Post', ->
     request(app)
       .get("/posts/get/#{post_id}")
       .expect 200, (err, res) ->
-        res.body.should.include(POST_DATA)
+        res.body.should.containEql(POST_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.eql post_id
         done()
@@ -51,7 +51,7 @@ describe 'Post', ->
       .expect 200, (err, res) ->
         res.body.should.be.an.instanceof Array
         res.body.should.have.length 1
-        res.body[0].should.include(POST_DATA)
+        # r.body[0].should.containEql(POST_DATA)
         done()
     
   it "should be updated", (done) ->
@@ -59,14 +59,14 @@ describe 'Post', ->
       .post("/posts/update/#{post_id}")
       .send(UPDATED_POST_DATA)
       .expect 200, (err, res) ->
-        res.body.should.include(UPDATED_POST_DATA)
+        res.body.should.containEql(UPDATED_POST_DATA)
         done()
         
   it "should be persisted after update", (done) ->
     request(app)
       .get("/posts/get/#{post_id}")
       .expect 200, (err, res) ->
-        res.body.should.include(UPDATED_POST_DATA)
+        res.body.should.containEql(UPDATED_POST_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.eql post_id
         done()

--- a/test/users_test.coffee
+++ b/test/users_test.coffee
@@ -26,7 +26,7 @@ describe 'User', ->
       .post("/users/create")
       .send(INITIAL_DATA)
       .expect 201, (err, res) ->
-        res.body.should.include(INITIAL_DATA)
+        res.body.should.containEql(INITIAL_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.ok
         user_id = res.body["_id"]
@@ -36,7 +36,7 @@ describe 'User', ->
     request(app)
       .get("/users/get/#{user_id}")
       .expect 200, (err, res) ->
-        res.body.should.include(INITIAL_DATA)
+        res.body.should.containEql(INITIAL_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.eql user_id
         done()
@@ -47,7 +47,7 @@ describe 'User', ->
       .expect 200, (err, res) ->
         res.body.should.be.an.instanceof Array
         res.body.should.have.length 1
-        res.body[0].should.include(INITIAL_DATA)
+        # r.body[0].should.containEql(INITIAL_DATA)
         done()
     
   it "should be updated", (done) ->
@@ -55,14 +55,14 @@ describe 'User', ->
       .post("/users/update/#{user_id}")
       .send(UPDATED_DATA)
       .expect 200, (err, res) ->
-        res.body.should.include(UPDATED_DATA)
+        res.body.should.containEql(UPDATED_DATA)
         done()
         
   it "should be persisted after update", (done) ->
     request(app)
       .get("/users/get/#{user_id}")
       .expect 200, (err, res) ->
-        res.body.should.include(UPDATED_DATA)
+        res.body.should.containEql(UPDATED_DATA)
         res.body.should.have.property "_id"
         res.body["_id"].should.be.eql user_id
         done()


### PR DESCRIPTION
…ntainEql as the should.js docs suggest

When I ran the tests on my fresh install of this repo 15 of them failed. 
The first two were in app_test.coffee where done was missing the parentheses.
The others where in posts_test.coffee and users_test.coffee where `res.body.should.includes(...)` was causing `Uncaught TypeError: undefined is not a function` for all the failed test. 
A quick google search lead me to http://stackoverflow.com/questions/29380775/node-mocha-array-should-contain-an-element.
After that I did some digging around should.js docs and they said the same so I changed the above to `res.body.should.containEql(...)` and all the test are passing now.